### PR TITLE
Prepdocs aggregate exceptions

### DIFF
--- a/app/.editorconfig
+++ b/app/.editorconfig
@@ -5,7 +5,7 @@
 root = true
 # All files
 [*]
-indent_style = space
+indent_style = tab
 end_of_line = lf
 
 # XML project files
@@ -177,6 +177,9 @@ dotnet_naming_rule.private_fields_underscored.severity = error
 dotnet_naming_rule.async_methods_end_in_async.symbols = any_async_methods
 dotnet_naming_rule.async_methods_end_in_async.style = end_in_async
 dotnet_naming_rule.async_methods_end_in_async.severity = error
+dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_allow_multiple_blank_lines_experimental = true:silent
+dotnet_style_allow_statement_immediately_after_block_experimental = true:silent
 
 ###############################
 # C# Coding Conventions       #
@@ -202,7 +205,7 @@ csharp_style_conditional_delegate_call = true:suggestion
 # Modifier preferences
 csharp_preferred_modifier_order = public,private,protected,internal,static,extern,new,virtual,abstract,sealed,override,readonly,unsafe,volatile,async:suggestion
 # Expression-level preferences
-csharp_prefer_braces = true:error
+csharp_prefer_braces = when_multiline:error
 csharp_style_deconstructed_variable_declaration = true:suggestion
 csharp_prefer_simple_default_expression = true:suggestion
 csharp_style_prefer_local_over_anonymous_function = true:error
@@ -269,6 +272,27 @@ dotnet_diagnostic.IDE0060.severity = none # Remove unused parameter
 dotnet_diagnostic.IDE0080.severity = none # Remove unnecessary suppression operator
 dotnet_diagnostic.IDE0100.severity = none # Remove unnecessary equality operator
 dotnet_diagnostic.IDE0110.severity = none # Remove unnecessary discards
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_style_prefer_null_check_over_type_check = true:suggestion
+csharp_style_prefer_index_operator = true:suggestion
+csharp_style_prefer_range_operator = true:suggestion
+csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_prefer_tuple_swap = true:suggestion
+csharp_style_prefer_utf8_string_literals = true:suggestion
+csharp_style_unused_value_assignment_preference = discard_variable:suggestion
+csharp_style_unused_value_expression_statement_preference = discard_variable:silent
+csharp_prefer_static_local_function = true:suggestion
+csharp_style_prefer_readonly_struct = true:suggestion
+csharp_style_prefer_readonly_struct_member = true:suggestion
+csharp_style_allow_blank_lines_between_consecutive_braces_experimental = true:silent
+csharp_style_allow_embedded_statements_on_same_line_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_conditional_expression_experimental = true:silent
+csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent
+csharp_style_allow_blank_line_after_token_in_arrow_expression_clause_experimental = true:silent
+csharp_style_prefer_switch_expression = true:suggestion
+csharp_style_prefer_pattern_matching = true:silent
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
 
 
 ###############################


### PR DESCRIPTION
This pull request primarily focuses on two areas: updating the `.editorconfig` file to modify the coding style rules and handling exceptions in the `Program.cs` file. In the `.editorconfig`, the indent style has been changed, and several new coding style rules have been added. In the `Program.cs` file, the exception handling has been updated to collect all exceptions into a list and throw an `AggregateException` at the end if there are any exceptions in the list.

Updates to `.editorconfig`:

* [`app/.editorconfig`](diffhunk://#diff-70250d5318abb0f88c0e4af63d44b07e202eb0be9f88f0f6e5d517c1391a595bL8-R8): The indent style has been changed from spaces to tabs.
* [`app/.editorconfig`](diffhunk://#diff-70250d5318abb0f88c0e4af63d44b07e202eb0be9f88f0f6e5d517c1391a595bR180-R182): Several new coding style rules have been added, including `dotnet_style_prefer_collection_expression`, `dotnet_style_allow_multiple_blank_lines_experimental`, and `dotnet_style_allow_statement_immediately_after_block_experimental`.
* [`app/.editorconfig`](diffhunk://#diff-70250d5318abb0f88c0e4af63d44b07e202eb0be9f88f0f6e5d517c1391a595bL205-R208): The `csharp_prefer_braces` rule has been updated to apply only when multiline.
* [`app/.editorconfig`](diffhunk://#diff-70250d5318abb0f88c0e4af63d44b07e202eb0be9f88f0f6e5d517c1391a595bR275-R295): Numerous new coding style rules have been added, such as `csharp_style_prefer_primary_constructors`, `csharp_style_prefer_null_check_over_type_check`, and `csharp_style_prefer_index_operator`.

Changes to exception handling:

* [`app/prepdocs/PrepareDocs/Program.cs`](diffhunk://#diff-7325b26585a4f4849209d53bbcb56787f013a654a30d963b61bc6bb8a0514e46R27-R28): A list named `exceptions` has been added to collect all exceptions.
* [`app/prepdocs/PrepareDocs/Program.cs`](diffhunk://#diff-7325b26585a4f4849209d53bbcb56787f013a654a30d963b61bc6bb8a0514e46L36-R55): Instead of throwing exceptions immediately, they are now added to the `exceptions` list. If there are any exceptions in the list after all tasks have been processed, an `AggregateException` is thrown.