### PR TITLE
Fix bug with passing BatchSize and WaitTime to PrepareDocs as command…

### DIFF
--- a/app/prepdocs/PrepareDocs/Program.Options.cs
+++ b/app/prepdocs/PrepareDocs/Program.Options.cs
@@ -73,6 +73,8 @@ internal static partial class Program
             s_formRecognizerServiceEndpoint,
             s_computerVisionServiceEndpoint,
             s_verbose,
+            s_batchSize,
+            s_waitTime
         };
 
     private static AppOptions GetParsedAppOptions(InvocationContext context) => new(


### PR DESCRIPTION
This pull request includes a minor update to the `internal static partial class Program` in the `app/prepdocs/PrepareDocs/Program.Options.cs` file. The change adds two new options, `s_batchSize` and `s_waitTime`, to the program options.… line arguments