### PR TITLE
Add TotalTokens property and update array initializations

### DIFF
--- a/app/SharedWebComponents/Pages/Chat.razor.cs
+++ b/app/SharedWebComponents/Pages/Chat.razor.cs
@@ -2,6 +2,7 @@
 
 using Microsoft.AspNetCore.WebUtilities;
 using System;
+using System.Linq;
 
 namespace SharedWebComponents.Pages;
 
@@ -111,10 +112,12 @@ public sealed partial class Chat
         {
             var history = _questionAndAnswerMap
                 .Where(x => x.Value?.Choices is { Length: > 0 })
-                .SelectMany(x => new ChatMessage[] { new ChatMessage("user", x.Key.Question), new ChatMessage("assistant", x.Value!.Choices[0].Message.Content) })
+                .SelectMany(x => new ChatMessage[] {
+                    new ChatMessage("user", x.Key.Question, 0),
+                    new ChatMessage("assistant", x.Value!.Choices[0].Message.Content, x.Value!.Choices[0].Message.TotalTokens) })
                 .ToList();
 
-            history.Add(new ChatMessage("user", _userQuestion));
+            history.Add(new ChatMessage("user", _userQuestion, 0));
 
             var request = new ChatRequest([.. history], Settings.Overrides);
             var result = await ApiClient.ChatConversationAsync(request);

--- a/app/shared/Shared/Models/ChatMessage.cs
+++ b/app/shared/Shared/Models/ChatMessage.cs
@@ -6,7 +6,8 @@ namespace Shared.Models;
 
 public record ChatMessage(
     [property:JsonPropertyName("role")] string Role,
-    [property: JsonPropertyName("content")] string Content)
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("totalTokens")] int TotalTokens)
 {
     public bool IsUser => Role == "user";
 }

--- a/app/shared/Shared/Models/ResponseChoice.cs
+++ b/app/shared/Shared/Models/ResponseChoice.cs
@@ -33,7 +33,8 @@ public record ResponseContext(
 
 public record ResponseMessage(
     [property: JsonPropertyName("role")] string Role,
-    [property: JsonPropertyName("content")] string Content)
+    [property: JsonPropertyName("content")] string Content,
+    [property: JsonPropertyName("totalTokens")] int TotalTokens)
 {
 }
 

--- a/app/tests/MinimalApi.Tests/ReadRetrieveReadChatServiceTest.cs
+++ b/app/tests/MinimalApi.Tests/ReadRetrieveReadChatServiceTest.cs
@@ -50,7 +50,7 @@ public class ReadRetrieveReadChatServiceTest
 
         var history = new ChatMessage[]
         {
-            new ChatMessage("What is included in my Northwind Health Plus plan that is not in standard?", "user"),
+            new ChatMessage("What is included in my Northwind Health Plus plan that is not in standard?", "user", 0),
         };
         var overrides = new RequestOverrides
         {


### PR DESCRIPTION
Updated Chat.razor.cs to include System.Linq and modified ChatMessage constructor calls to include a new TotalTokens parameter. Enhanced ReadRetrieveReadChatService.cs with Blazor.Serialization.Extensions and System.Text.Json namespaces, and logic to extract TotalTokens from answer.Metadata. Added TotalTokens property to ChatMessage and ResponseMessage classes, serialized as totalTokens. Updated ResponseContext and ChatAppResponse return statement to use array initialization syntax.